### PR TITLE
Implement bridge discovery via multiroom

### DIFF
--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -285,3 +285,4 @@ class MultiroomAttribute(StrEnum):
     NUM_FOLLOWERS = "slaves"
     FOLLOWER_LIST = "slave_list"
     UUID = "uuid"
+    IP = "ip"

--- a/src/linkplay/discovery.py
+++ b/src/linkplay/discovery.py
@@ -63,7 +63,7 @@ async def discover_multirooms(bridges: list[LinkPlayBridge]) -> list[LinkPlayMul
         followers: list[LinkPlayBridge] = []
         for follower in properties[MultiroomAttribute.FOLLOWER_LIST]:
             if follower[MultiroomAttribute.UUID] in bridges_dict:
-                followers.append(bridges_dict[MultiroomAttribute.UUID])
+                followers.append(bridges_dict[follower[MultiroomAttribute.UUID]])
 
         multirooms.append(LinkPlayMultiroom(bridge, followers))
 


### PR DESCRIPTION
Implements bridge discovery through multirooms.

Currently, when a bridge is the follower of a leader bridge, it will not answer on the discovery process. To aid this, read the multiroom properties of a bridge to discover its follower bridges and add these to the bridge list.