### PR TITLE
Catch decode_hexstr ValueError

### DIFF
--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -56,4 +56,7 @@ async def session_call_api_ok(endpoint: str, session: ClientSession, command: st
 
 def decode_hexstr(hexstr: str) -> str:
     """Decode a hex string."""
-    return bytes.fromhex(hexstr).decode("utf-8")
+    try:
+        return bytes.fromhex(hexstr).decode("utf-8")
+    except ValueError:
+        return hexstr

--- a/tests/linkplay/test_utils.py
+++ b/tests/linkplay/test_utils.py
@@ -4,3 +4,8 @@ from linkplay.utils import decode_hexstr
 def test_decode_hexstr():
     """Tests the decode_hexstr function."""
     assert "Unknown" == decode_hexstr('556E6B6E6F776E')
+
+
+def test_decode_hexstr_invalid():
+    """Tests the decode_hexstr function upon invalid input."""
+    assert "ABCDEFGHIJKLMNOPQRSTUVWXYZ" == decode_hexstr('ABCDEFGHIJKLMNOPQRSTUVWXYZ')


### PR DESCRIPTION
Catch ValueError thrown in `decode_hexstr()` by returning the original string.