### PR TITLE
Feature: Configure ex commands and mtls

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -153,16 +153,22 @@ class LinkPlayPlayer:
     @property
     def title(self) -> str:
         """Returns if the currently playing title of the track."""
+        if not PlayerAttribute.TITLE in self.properties:
+            return ""
         return self.properties[PlayerAttribute.TITLE]
 
     @property
     def artist(self) -> str:
         """Returns if the currently playing artist."""
+        if not PlayerAttribute.ARTIST in self.properties:
+            return ""
         return self.properties[PlayerAttribute.ARTIST]
 
     @property
     def album(self) -> str:
         """Returns if the currently playing album."""
+        if not PlayerAttribute.ALBUM in self.properties:
+            return ""
         return self.properties[PlayerAttribute.ALBUM]
 
     @property

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -223,15 +223,13 @@ class LinkPlayBridge:
     protocol: str
     ip_address: str
     session: ClientSession
-    use_ex_endpoints: bool
     device: LinkPlayDevice
     player: LinkPlayPlayer
 
-    def __init__(self, protocol: str, ip_address: str, session: ClientSession, use_ex_endpoints: bool = False):
+    def __init__(self, protocol: str, ip_address: str, session: ClientSession):
         self.protocol = protocol
         self.ip_address = ip_address
         self.session = session
-        self.use_ex_endpoints = use_ex_endpoints
         self.device = LinkPlayDevice(self)
         self.player = LinkPlayPlayer(self)
 
@@ -248,13 +246,6 @@ class LinkPlayBridge:
 
     async def json_request(self, command: str) -> dict[str, str]:
         """Performs a GET request on the given command and returns the result as a JSON object."""
-
-        if self.use_ex_endpoints:
-            if command == LinkPlayCommand.DEVICE_STATUS:
-                command = LinkPlayCommand.DEVICE_STATUS_EX
-            if command == LinkPlayCommand.PLAYER_STATUS:
-                command = LinkPlayCommand.PLAYER_STATUS_EX
-
         return await session_call_api_json(self.endpoint, self.session, command)
 
     async def request(self, command: str) -> None:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -217,13 +217,15 @@ class LinkPlayBridge:
     protocol: str
     ip_address: str
     session: ClientSession
+    use_ex_endpoints: bool
     device: LinkPlayDevice
     player: LinkPlayPlayer
 
-    def __init__(self, protocol: str, ip_address: str, session: ClientSession):
+    def __init__(self, protocol: str, ip_address: str, session: ClientSession, use_ex_endpoints: bool = False):
         self.protocol = protocol
         self.ip_address = ip_address
         self.session = session
+        self.use_ex_endpoints = use_ex_endpoints
         self.device = LinkPlayDevice(self)
         self.player = LinkPlayPlayer(self)
 
@@ -240,6 +242,13 @@ class LinkPlayBridge:
 
     async def json_request(self, command: str) -> dict[str, str]:
         """Performs a GET request on the given command and returns the result as a JSON object."""
+
+        if self.use_ex_endpoints:
+            if command == LinkPlayCommand.DEVICE_STATUS:
+                command = LinkPlayCommand.DEVICE_STATUS_EX
+            if command == LinkPlayCommand.PLAYER_STATUS:
+                command = LinkPlayCommand.PLAYER_STATUS_EX
+
         return await session_call_api_json(self.endpoint, self.session, command)
 
     async def request(self, command: str) -> None:

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -10,12 +10,10 @@ class LinkPlayCommand(StrEnum):
     """Defines the LinkPlay commands."""
 
     DEVICE_STATUS = "getStatus"
-    DEVICE_STATUS_EX = "getStatusEx"
     SYSLOG = "getsyslog"
     UPDATE_SERVER = "GetUpdateServer"
     REBOOT = "reboot"
     PLAYER_STATUS = "getPlayerStatus"
-    PLAYER_STATUS_EX = "getPlayerStatusEx"
     NEXT = "setPlayerCmd:next"
     PREVIOUS = "setPlayerCmd:prev"
     UNMUTE = "setPlayerCmd:mute:0"

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -10,10 +10,12 @@ class LinkPlayCommand(StrEnum):
     """Defines the LinkPlay commands."""
 
     DEVICE_STATUS = "getStatus"
+    DEVICE_STATUS_EX = "getStatusEx"
     SYSLOG = "getsyslog"
     UPDATE_SERVER = "GetUpdateServer"
     REBOOT = "reboot"
     PLAYER_STATUS = "getPlayerStatus"
+    PLAYER_STATUS_EX = "getPlayerStatusEx"
     NEXT = "setPlayerCmd:next"
     PREVIOUS = "setPlayerCmd:prev"
     UNMUTE = "setPlayerCmd:mute:0"

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -9,11 +9,11 @@ UPNP_DEVICE_TYPE = "urn:schemas-upnp-org:device:MediaRenderer:1"
 class LinkPlayCommand(StrEnum):
     """Defines the LinkPlay commands."""
 
-    DEVICE_STATUS = "getStatus"
+    DEVICE_STATUS = "getStatusEx"
     SYSLOG = "getsyslog"
     UPDATE_SERVER = "GetUpdateServer"
     REBOOT = "reboot"
-    PLAYER_STATUS = "getPlayerStatus"
+    PLAYER_STATUS = "getPlayerStatusEx"
     NEXT = "setPlayerCmd:next"
     PREVIOUS = "setPlayerCmd:prev"
     UNMUTE = "setPlayerCmd:mute:0"

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -1,8 +1,5 @@
-from http import HTTPStatus
-from unittest import mock
-from unittest.mock import AsyncMock, PropertyMock
+from unittest.mock import AsyncMock
 
-import pytest
 from linkplay.bridge import (
     LinkPlayBridge,
     LinkPlayDevice,
@@ -10,7 +7,6 @@ from linkplay.bridge import (
     LinkPlayPlayer,
 )
 from linkplay.consts import (
-    API_ENDPOINT,
     PLAY_MODE_SEND_MAP,
     DeviceAttribute,
     EqualizerMode,
@@ -300,28 +296,3 @@ async def test_multiroom_set_volume():
     await multiroom.set_volume(100)
 
     leader.request.assert_called_once_with(LinkPlayCommand.MULTIROOM_VOL.format(100))
-
-
-async def test_bridge_translates_required_ex_calls():
-    """Tests mapping to "Ex" commands if turned on."""
-    async def test_bridge_maps_ex_calls_correctly(use_ex_endpoints, initial_command, expected_command):
-        protocol = "https"
-        endpoint = "1.2.3.4"
-        expected_url = API_ENDPOINT.format(protocol + "://" + endpoint, expected_command)
-
-        response = AsyncMock()
-        response.text.return_value = "{ \"message\": \"Successful test\" }"
-        response.status = HTTPStatus.OK
-        session = AsyncMock()
-        session.get.return_value = response
-        
-        bridge = LinkPlayBridge(protocol, endpoint, session, use_ex_endpoints)
-        response = await bridge.json_request(initial_command)
-        session.get.assert_called_once_with(expected_url, ssl=False)
-
-        assert response['message'] == "Successful test"
-
-    await test_bridge_maps_ex_calls_correctly(False, LinkPlayCommand.DEVICE_STATUS, LinkPlayCommand.DEVICE_STATUS)
-    await test_bridge_maps_ex_calls_correctly(False, LinkPlayCommand.DEVICE_STATUS, LinkPlayCommand.DEVICE_STATUS)
-    await test_bridge_maps_ex_calls_correctly(True, LinkPlayCommand.DEVICE_STATUS, LinkPlayCommand.DEVICE_STATUS_EX)
-    await test_bridge_maps_ex_calls_correctly(True, LinkPlayCommand.PLAYER_STATUS, LinkPlayCommand.PLAYER_STATUS_EX)


### PR DESCRIPTION
This PR addresses #18 and allows at least two new LinkPlay player types to work:

* [WiiM Pro](https://www.wiimhome.com/wiimpro/overview)
* [Edifier M50A](https://www.edifier.com/global/p/wireless-speakers/ms50a)

### New Features
**Ex endpoints**
Both of these LinkPlay device types use the `*Ex` endpoints for `getStatus` (`getStatusEx`) and `getPlayerStatus` (`getPlayerStatusEx`).

~**mTLS authentication**~
~The Edifiers also use mTLS and a particular certificate to communicate.  Without these changes, these kinds of speakers will never work.~

### Minor fixes
I've also added a null check on the player status properties for title, artist and album.  Each of these endpoints throw an exception if the player doesn't contain these keys (which, depending on the media being played, they don't).

Open to any feedback you might have!  I've already started work on an associated Home Assistant PR, but will hold off pushing anything until this is definitely approved.

Thanks again for all your great work!