### PR TITLE
Add support for RCA PlayingMode

### DIFF
--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -167,6 +167,7 @@ class InputMode(IntFlag):
     BLUETOOTH = 4
     USB = 8
     OPTICAL = 16
+    RCA = 32
     COAXIAL = 64
     LINE_IN_2 = 256
     USB_DAC = 32768
@@ -179,6 +180,7 @@ INPUT_MODE_MAP: dict[InputMode, PlayingMode] = {
     InputMode.BLUETOOTH: PlayingMode.BLUETOOTH,
     InputMode.USB: PlayingMode.UDISK,
     InputMode.OPTICAL: PlayingMode.OPTICAL,
+    InputMode.RCA: PlayingMode.RCA,
     InputMode.COAXIAL: PlayingMode.COAXIAL,
     InputMode.LINE_IN_2: PlayingMode.LINE_IN_2,
     InputMode.USB_DAC: PlayingMode.USB_DAC,


### PR DESCRIPTION
I have [Triangle AIO Twin](https://trianglehifi.com/products/aio-twin) speakers, which report `"plm_support": "0x36"`. I observed that bit 5 (32) is not mentioned in any LinkPlay documents I have found so far

On the other hand, the `mode` field in the `getPlayerStatus` API call output shows `0x44`, once the speakers are set up to the RCA output. The `setPlayerCmd:switchmode:RCA` API call works correctly.

UPD: I decompiled the [Triangle's Android app](https://play.google.com/store/apps/details?id=com.wifiaudio.triangle) and found the following bit mapping:
> 2: Line-In
> 4: Bluetooth
> 8: USB
> 16: Optical
> 32: RCA
> 64: Coaxial
> 128: Radio
> 256: Line-In 2
> 512: XLR
> 1024: HDMI
> 2048: CD
> 4096: TF Card