### PR TITLE
Async mTLS file operation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     appdirs>=1.4.4
     async_upnp_client>=0.36.2
     deprecated>=1.2.14
+    aiofiles>=24.1.0
 python_requires = >=3.11
 package_dir =
     =src

--- a/src/linkplay/__main__.py
+++ b/src/linkplay/__main__.py
@@ -1,11 +1,11 @@
 import asyncio
 
 from linkplay.controller import LinkPlayController
-from linkplay.utils import create_unverified_client_session
+from linkplay.utils import async_create_unverified_client_session
 
 
 async def main():
-    async with create_unverified_client_session() as session:
+    async with await async_create_unverified_client_session() as session:
         controller = LinkPlayController(session)
 
         await controller.discover_bridges()

--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -97,7 +97,7 @@ async def async_create_unverified_context() -> ssl.SSLContext:
     ) as mtls_certificate:
         await mtls_certificate.write(MTLS_CERTIFICATE_CONTENTS)
         await mtls_certificate.flush()
-        return create_ssl_context(path=mtls_certificate.name)
+        return create_ssl_context(path=str(mtls_certificate.name))
 
 
 def create_ssl_context(path: str) -> ssl.SSLContext:

--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -11,7 +11,6 @@ import aiofiles
 import async_timeout
 from aiohttp import ClientError, ClientSession, TCPConnector
 from appdirs import AppDirs
-from deprecated import deprecated
 
 from linkplay.consts import API_ENDPOINT, API_TIMEOUT, MTLS_CERTIFICATE_CONTENTS
 from linkplay.exceptions import LinkPlayRequestException

--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -7,9 +7,11 @@ import ssl
 from http import HTTPStatus
 from typing import Dict
 
+import aiofiles
 import async_timeout
 from aiohttp import ClientError, ClientSession, TCPConnector
 from appdirs import AppDirs
+from deprecated import deprecated
 
 from linkplay.consts import API_ENDPOINT, API_TIMEOUT, MTLS_CERTIFICATE_CONTENTS
 from linkplay.exceptions import LinkPlayRequestException
@@ -86,12 +88,25 @@ def create_unverified_context() -> ssl.SSLContext:
         with open(mtls_certificate_path, "w", encoding="utf-8") as file:
             file.write(MTLS_CERTIFICATE_CONTENTS)
 
-    sslcontext: ssl.SSLContext = ssl.create_default_context(
-        purpose=ssl.Purpose.SERVER_AUTH
-    )
-    sslcontext.load_cert_chain(certfile=mtls_certificate_path)
+    return create_ssl_context(path=mtls_certificate_path)
+
+
+async def async_create_unverified_context() -> ssl.SSLContext:
+    """Asynchronously creates an unverified SSL context with the default mTLS certificate."""
+    async with aiofiles.tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8"
+    ) as mtls_certificate:
+        await mtls_certificate.write(MTLS_CERTIFICATE_CONTENTS)
+        await mtls_certificate.flush()
+        return create_ssl_context(path=mtls_certificate.name)
+
+
+def create_ssl_context(path: str) -> ssl.SSLContext:
+    """Creates an SSL context from given certificate file."""
+    sslcontext: ssl.SSLContext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     sslcontext.check_hostname = False
     sslcontext.verify_mode = ssl.CERT_NONE
+    sslcontext.load_cert_chain(certfile=path)
     with contextlib.suppress(AttributeError):
         # This only works for OpenSSL >= 1.0.0
         sslcontext.options |= ssl.OP_NO_COMPRESSION
@@ -102,5 +117,12 @@ def create_unverified_context() -> ssl.SSLContext:
 def create_unverified_client_session() -> ClientSession:
     """Creates a ClientSession using the default unverified SSL context"""
     context: ssl.SSLContext = create_unverified_context()
+    connector: TCPConnector = TCPConnector(family=socket.AF_UNSPEC, ssl=context)
+    return ClientSession(connector=connector)
+
+
+async def async_create_unverified_client_session() -> ClientSession:
+    """Asynchronously creates a ClientSession using the default unverified SSL context"""
+    context: ssl.SSLContext = await async_create_unverified_context()
     connector: TCPConnector = TCPConnector(family=socket.AF_UNSPEC, ssl=context)
     return ClientSession(connector=connector)


### PR DESCRIPTION
This PR implements two new functions to create the `SSLContext (async_create_unverified_context)` and `ClientSession (async_create_unverified_client_session)` asynchronously. 

The cert chain file written for `SSLContext` is now written asynchronously as a tempfile with `aiofiles`. Loading the cert file with the `load_cert_chain()` function is still synchronous as there is no async variant.


The PR also splits off the `SSLContext` creation in `create_ssl_context` as it is duplicated for both `async_create_unverified_context` and `create_unverified_context` and optimizes it by creating it directly.