### PR TITLE
Feature: Play preset

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -148,6 +148,10 @@ class LinkPlayPlayer:
             LinkPlayCommand.SWITCH_MODE.format(PLAY_MODE_SEND_MAP[mode])
         )  # type: ignore[str-format]
 
+    async def play_preset(self, preset_number: int) -> None:
+        """Play a preset."""
+        await self.bridge.request(LinkPlayCommand.PLAY_PRESET.format(preset_number))
+
     @property
     def muted(self) -> bool:
         """Returns if the player is muted."""

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -150,6 +150,7 @@ class LinkPlayPlayer:
 
     async def play_preset(self, preset_number: int) -> None:
         """Play a preset."""
+        assert 0 < preset_number <= 10
         await self.bridge.request(LinkPlayCommand.PLAY_PRESET.format(preset_number))
 
     @property

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -151,7 +151,8 @@ class LinkPlayPlayer:
 
     async def play_preset(self, preset_number: int) -> None:
         """Play a preset."""
-        assert 0 < preset_number <= 10
+        if not 0 < preset_number <= 10:
+            raise ValueError("Preset must be between 1 and 10.")
         await self.bridge.request(LinkPlayCommand.PLAY_PRESET.format(preset_number))
 
     @property

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -89,6 +89,7 @@ class LinkPlayCommand(StrEnum):
     MULTIROOM_MUTE = "setPlayerCmd:slave_mute:mute"
     MULTIROOM_UNMUTE = "setPlayerCmd:slave_mute:unmute"
     MULTIROOM_JOIN = "ConnectMasterAp:JoinGroupMaster:eth{}:wifi0.0.0.0"
+    PLAY_PRESET = "MCUKeyShortClick:{}"
 
 
 class SpeakerType(StrEnum):

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -253,7 +253,7 @@ async def test_player_play_preset(preset_number: int):
         11,
     ],
 )
-async def test_player_play_preset_raises_value_error(preset_number: Any):
+async def test_player_play_preset_raises_value_error(preset_number: int):
     """Tests that a player fails in an expected way if play preset input is incorrect."""
     bridge = AsyncMock()
     player = LinkPlayPlayer(bridge)

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -233,16 +233,33 @@ async def test_player_set_play_mode():
     )
 
 
-async def test_player_play_preset():
+@pytest.mark.parametrize("preset_number", range(1, 11))
+async def test_player_play_preset(preset_number: int):
+    """Tests if a player is able to play a preset."""
     bridge = AsyncMock()
     player = LinkPlayPlayer(bridge)
-    preset_number = 2
 
     await player.play_preset(preset_number)
 
     bridge.request.assert_called_once_with(
         LinkPlayCommand.PLAY_PRESET.format(preset_number)
     )
+
+
+@pytest.mark.parametrize(
+    "preset_number",
+    [
+        0,
+        11,
+    ],
+)
+async def test_player_play_preset_raises_value_error(preset_number: Any):
+    """Tests that a player fails in an expected way if play preset input is incorrect."""
+    bridge = AsyncMock()
+    player = LinkPlayPlayer(bridge)
+
+    with pytest.raises(ValueError):
+        await player.play_preset(preset_number)
 
 
 async def test_multiroom_setup():

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -210,6 +210,18 @@ async def test_player_set_play_mode():
     )
 
 
+async def test_player_play_preset():
+    bridge = AsyncMock()
+    player = LinkPlayPlayer(bridge)
+    preset_number = 2
+
+    await player.play_preset(preset_number)
+
+    bridge.request.assert_called_once_with(
+        LinkPlayCommand.PLAY_PRESET.format(preset_number)
+    )
+
+
 async def test_multiroom_setup():
     """Tests if multiroom sets up correctly."""
     leader = AsyncMock()


### PR DESCRIPTION
Adds a function to play a preset via the HTTP API.

As per discussion in #31, I was unable to find a similar API endpoint to play the "Next" preset (similar to `MCU+KEY+NXT`), so that functionality would require the TCPUART API alongside the HTTP one.