### PR TITLE
Expand tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 minversion = 4.6.0
-envlist = py311, ruff, mypy
+envlist = py{311,312},ruff,mypy
 isolated_build = true
 
 [gh-actions]
 python =
     3.11: py311, mypy, ruff
+    3.12: py312, mypy, ruff
 
 [testenv]
 package = wheel
@@ -17,12 +18,12 @@ commands =
     pytest --cov-report html:htmlcov/pytest --basetemp={envtmpdir}
 
 [testenv:ruff]
-basepython = python3.11
 deps = ruff
-commands = ruff check src tests
+commands =
+    ruff check --fix --verbose src tests
+    ruff format --verbose src tests
 
 [testenv:mypy]
-basepython = python3.11
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands = mypy --install-types --non-interactive src


### PR DESCRIPTION
This PR adds Python 3.12 for tests and adds expands ruff commands