### PR TITLE
Introduce fixup_player_properties

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -35,10 +35,7 @@ class LinkPlayDevice:
 
     async def update_status(self) -> None:
         """Update the device status."""
-        properties: dict[PlayerAttribute, str] = await self.bridge.json_request(
-            LinkPlayCommand.PLAYER_STATUS
-        )  # type: ignore[assignment]
-        self.properties = fixup_player_properties(properties)
+        self.properties = await self.bridge.json_request(LinkPlayCommand.DEVICE_STATUS)  # type: ignore[assignment]
 
     async def reboot(self) -> None:
         """Reboot the device."""
@@ -86,9 +83,11 @@ class LinkPlayPlayer:
 
     async def update_status(self) -> None:
         """Update the player status."""
-        self.properties = fixup_player_properties(
-            await self.bridge.json_request(LinkPlayCommand.PLAYER_STATUS)
+        properties: dict[PlayerAttribute, str] = await self.bridge.json_request(
+            LinkPlayCommand.PLAYER_STATUS
         )
+
+        self.properties = fixup_player_properties(properties)
 
     async def next(self) -> None:
         """Play the next song in the playlist."""

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -35,7 +35,10 @@ class LinkPlayDevice:
 
     async def update_status(self) -> None:
         """Update the device status."""
-        self.properties = await self.bridge.json_request(LinkPlayCommand.DEVICE_STATUS)  # type: ignore[assignment]
+        properties: dict[PlayerAttribute, str] = await self.bridge.json_request(
+            LinkPlayCommand.PLAYER_STATUS
+        )  # type: ignore[assignment]
+        self.properties = fixup_player_properties(properties)
 
     async def reboot(self) -> None:
         """Reboot the device."""

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -85,7 +85,7 @@ class LinkPlayPlayer:
         """Update the player status."""
         properties: dict[PlayerAttribute, str] = await self.bridge.json_request(
             LinkPlayCommand.PLAYER_STATUS
-        )
+        )  # type: ignore[assignment]
 
         self.properties = fixup_player_properties(properties)
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -19,7 +19,7 @@ from linkplay.consts import (
     SpeakerType,
 )
 from linkplay.endpoint import LinkPlayEndpoint
-from linkplay.utils import decode_hexstr
+from linkplay.utils import fixup_player_properties
 
 
 class LinkPlayDevice:
@@ -83,10 +83,9 @@ class LinkPlayPlayer:
 
     async def update_status(self) -> None:
         """Update the player status."""
-        self.properties = await self.bridge.json_request(LinkPlayCommand.PLAYER_STATUS)  # type: ignore[assignment]
-        self.properties[PlayerAttribute.TITLE] = decode_hexstr(self.title)
-        self.properties[PlayerAttribute.ARTIST] = decode_hexstr(self.artist)
-        self.properties[PlayerAttribute.ALBUM] = decode_hexstr(self.album)
+        self.properties = fixup_player_properties(
+            await self.bridge.json_request(LinkPlayCommand.PLAYER_STATUS)
+        )
 
     async def next(self) -> None:
         """Play the next song in the playlist."""

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -60,7 +60,7 @@ async def test_device_reboot():
 
 
 async def test_player_update_status():
-    """Tests if the player update status is correctly called."""
+    """Tests if the player update_status is correctly called."""
     bridge = AsyncMock()
     bridge.json_request.return_value = {}
     player = LinkPlayPlayer(bridge)
@@ -71,7 +71,7 @@ async def test_player_update_status():
 
 
 async def test_player_update_status_calls_fixup_player_properties():
-    """Tests if the player update status is correctly called."""
+    """Tests if the player update_status calls fixup_player_properties."""
 
     with patch("linkplay.bridge.fixup_player_properties") as fixup_mock:
         bridge = AsyncMock()

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -1,7 +1,7 @@
 """Test bridge functionality."""
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -62,17 +62,24 @@ async def test_device_reboot():
 async def test_player_update_status():
     """Tests if the player update status is correctly called."""
     bridge = AsyncMock()
-    bridge.json_request.return_value = {
-        PlayerAttribute.TITLE: "556E6B6E6F776E",
-        PlayerAttribute.ARTIST: "556E6B6E6F776E",
-        PlayerAttribute.ALBUM: "556E6B6E6F776E",
-    }
+    bridge.json_request.return_value = {}
     player = LinkPlayPlayer(bridge)
 
     await player.update_status()
 
     bridge.json_request.assert_called_once_with(LinkPlayCommand.PLAYER_STATUS)
-    assert player.title == "Unknown"
+
+
+async def test_player_update_status_calls_fixup_player_properties():
+    """Tests if the player update status is correctly called."""
+
+    with patch("linkplay.bridge.fixup_player_properties") as fixup_mock:
+        bridge = AsyncMock()
+        player = LinkPlayPlayer(bridge)
+
+        await player.update_status()
+
+        fixup_mock.assert_called_once()
 
 
 async def test_player_next():

--- a/tests/linkplay/test_utils.py
+++ b/tests/linkplay/test_utils.py
@@ -1,6 +1,7 @@
 """Test utility functions."""
 
-from linkplay.utils import decode_hexstr
+from linkplay.consts import PlayerAttribute, PlayingStatus
+from linkplay.utils import decode_hexstr, fixup_player_properties
 
 
 def test_decode_hexstr():
@@ -11,3 +12,29 @@ def test_decode_hexstr():
 def test_decode_hexstr_invalid():
     """Tests the decode_hexstr function upon invalid input."""
     assert "ABCDEFGHIJKLMNOPQRSTUVWXYZ" == decode_hexstr("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+
+def test_fixup_player_properties_decodes_hexstr():
+    """Tests if the fixup_player_properties function properly fixes the dict."""
+    test_dict: dict[PlayerAttribute, str] = {
+        PlayerAttribute.ARTIST: "556E6B6E6F776E",
+        PlayerAttribute.TITLE: "556E6B6E6F776E",
+        PlayerAttribute.ALBUM: "556E6B6E6F776E",
+    }
+
+    fixed_dict: dict[PlayerAttribute, str] = fixup_player_properties(test_dict)
+
+    assert fixed_dict[PlayerAttribute.ARTIST] == "Unknown"
+    assert fixed_dict[PlayerAttribute.TITLE] == "Unknown"
+    assert fixed_dict[PlayerAttribute.ALBUM] == "Unknown"
+
+
+def test_fixup_player_properties_fixes_playing_status():
+    """Tests if the fixup_player_properties function properly fixes the dict."""
+    test_dict: dict[PlayerAttribute, str] = {
+        PlayerAttribute.PLAYING_STATUS: "none",
+    }
+
+    fixed_dict: dict[PlayerAttribute, str] = fixup_player_properties(test_dict)
+
+    assert fixed_dict[PlayerAttribute.PLAYING_STATUS] == PlayingStatus.STOPPED


### PR DESCRIPTION
This PR implements the `fixup_player_properties` function. This function can be used on a `dict[PlayerAttribute, str]` to automatically decode the artist/album/title string and fixup the status if the value does not fall within our `PlayingStatus` enum.

This fixes #38 