### PR TITLE
Support devices running https on port 4443

### DIFF
--- a/src/linkplay/endpoint.py
+++ b/src/linkplay/endpoint.py
@@ -30,12 +30,14 @@ class LinkPlayEndpoint(ABC):
 class LinkPlayApiEndpoint(LinkPlayEndpoint):
     """Represents a LinkPlay HTTP API endpoint."""
 
-    def __init__(self, *, protocol: str, endpoint: str, session: ClientSession):
+    def __init__(
+        self, *, protocol: str, port: int, endpoint: str, session: ClientSession
+    ):
         assert protocol in [
             "http",
             "https",
         ], "Protocol must be either 'http' or 'https'"
-        self._endpoint: str = f"{protocol}://{endpoint}"
+        self._endpoint: str = f"{protocol}://{endpoint}:{port}"
         self._session: ClientSession = session
 
     def to_dict(self):

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
 from linkplay.bridge import (
     LinkPlayBridge,
     LinkPlayDevice,
@@ -27,10 +28,10 @@ from linkplay.endpoint import LinkPlayApiEndpoint
 def test_device_name():
     """Tests if the device name is correctly set up."""
     endpoint: LinkPlayApiEndpoint = LinkPlayApiEndpoint(
-        protocol="http", endpoint="1.2.3.4", session=None
+        protocol="http", port=80, endpoint="1.2.3.4", session=None
     )
     bridge: LinkPlayBridge = LinkPlayBridge(endpoint=endpoint)
-    assert f"{bridge}" == "http://1.2.3.4"
+    assert f"{bridge}" == "http://1.2.3.4:80"
 
     bridge.device.properties[DeviceAttribute.DEVICE_NAME] = "TestDevice"
     assert f"{bridge}" == "TestDevice"

--- a/tests/linkplay/test_endpoint.py
+++ b/tests/linkplay/test_endpoint.py
@@ -10,4 +10,4 @@ def test_api_endpoint_protocol_raises_assertion_error() -> None:
     with an invalid protocol raises an AssertionError."""
 
     with pytest.raises(AssertionError):
-        LinkPlayApiEndpoint(protocol="ftp", endpoint="1.2.3.4", session=None)
+        LinkPlayApiEndpoint(protocol="ftp", port=21, endpoint="1.2.3.4", session=None)


### PR DESCRIPTION
A none-python coders take on implementing #66

Will allow for communication with Audio Pro devices, but during the development of this I realized that the Audio Pro devices seems to support neither getPlayerStatus nor getPlayerStatusEx.

I guess that's why [linkplay_cli uses a UPNP based fallback to getPlayerStatus](https://github.com/ramikg/linkplay-cli/blob/master/linkplay_cli/cli.py#L169). I'm opening a new issue suggesting implementing a similar workaround.
