### PR TITLE
Unable to use `join` action due to incorrect IP address being fetched

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -72,18 +72,12 @@ class LinkPlayDevice:
     @property
     def eth(self) -> str | None:
         """Returns the ethernet address."""
-        eth2 = self.properties.get(DeviceAttribute.ETH2)
-        eth0 = self.properties.get(DeviceAttribute.ETH0)
-        for eth in [eth2, eth0]:
-            if eth == "0.0.0.0":
-                eth = None
-        return (
-            eth2
-            if eth2
-            else eth0
-            if eth0
-            else self.properties.get(DeviceAttribute.APCLI0)
-        )
+        eth = self.properties.get(DeviceAttribute.ETH2)
+        if eth == "0.0.0.0" or eth is None:
+          eth = self.properties.get(DeviceAttribute.ETH0)
+        if eth == "0.0.0.0" or eth is None:
+          eth = self.properties.get(DeviceAttribute.APCLI0)
+        return eth
 
     async def timesync(self) -> None:
         """Sync the time."""

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -74,9 +74,9 @@ class LinkPlayDevice:
         """Returns the ethernet address."""
         eth = self.properties.get(DeviceAttribute.ETH2)
         if eth == "0.0.0.0" or eth is None:
-          eth = self.properties.get(DeviceAttribute.ETH0)
+            eth = self.properties.get(DeviceAttribute.ETH0)
         if eth == "0.0.0.0" or eth is None:
-          eth = self.properties.get(DeviceAttribute.APCLI0)
+            eth = self.properties.get(DeviceAttribute.APCLI0)
         return eth
 
     async def timesync(self) -> None:


### PR DESCRIPTION
I haven't been able to use the join action from Home Assistant using the native Linkplay integration. After debugging it, I noticed that it was sending `0.0.0.0` as the address for the main device. 

The reason was that the correct address was being returned by `eth0`, with `eth2` being `0.0.0.0`. The `for` loop was supposed to correct it and set the value of `0.0.0.0` addresses to `None`, but since strings are immutable it wasn't changing the string value referenced by `eth2`. I've simplified the code to use a sequence of `if` statements until one with a valid address is found.