### PR TITLE
Fixup emtpy IP address accessed

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -83,9 +83,9 @@ class LinkPlayDevice:
     def eth(self) -> str | None:
         """Returns the ethernet address."""
         eth = self.properties.get(DeviceAttribute.ETH2)
-        if eth == "0.0.0.0" or eth is None:
+        if eth == "0.0.0.0" or eth == "" or eth is None:
             eth = self.properties.get(DeviceAttribute.ETH0)
-        if eth == "0.0.0.0" or eth is None:
+        if eth == "0.0.0.0" or eth == "" or eth is None:
             eth = self.properties.get(DeviceAttribute.APCLI0)
         return eth
 


### PR DESCRIPTION
On my Arylic S10+ devices `eth2` is an empty string when connected to wifi.
Could be fixing home-assistant/core/issues/135392, home-assistant/core/issues/134915.