### PR TITLE
Add available equalizer_modes

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -187,7 +187,26 @@ class LinkPlayPlayer:
 
     async def set_equalizer_mode(self, mode: EqualizerMode) -> None:
         """Set the equalizer mode."""
-        await self.bridge.request(LinkPlayCommand.EQUALIZER_MODE.format(mode))  # type: ignore[str-format]
+        equalizer_mode_as_number = None
+        match mode:
+            case EqualizerMode.NONE:
+                equalizer_mode_as_number = "0"
+            case EqualizerMode.CLASSIC:
+                equalizer_mode_as_number = "1"
+            case EqualizerMode.POP:
+                equalizer_mode_as_number = "2"
+            case EqualizerMode.JAZZ:
+                equalizer_mode_as_number = "3"
+            case EqualizerMode.VOCAL:
+                equalizer_mode_as_number = "4"
+        if equalizer_mode_as_number is None:
+            raise ValueError(
+                f"Invalid equalizer mode {mode}. Allowed equalizer modes are {self.available_equalizer_modes()}."
+            )
+
+        await self.bridge.request(
+            LinkPlayCommand.EQUALIZER_MODE.format(equalizer_mode_as_number)
+        )
 
     async def set_loop_mode(self, mode: LoopMode) -> None:
         """Set the loop mode."""
@@ -280,6 +299,11 @@ class LinkPlayPlayer:
         return EqualizerMode(
             self.properties.get(PlayerAttribute.EQUALIZER_MODE, EqualizerMode.CLASSIC)
         )
+
+    @property
+    def available_equalizer_modes(self) -> list[EqualizerMode]:
+        """Returns the available equalizer modes."""
+        return [equalizer_mode.value for equalizer_mode in EqualizerMode]
 
     @property
     def speaker_type(self) -> SpeakerType:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -303,7 +303,7 @@ class LinkPlayPlayer:
     @property
     def available_equalizer_modes(self) -> list[EqualizerMode]:
         """Returns the available equalizer modes."""
-        return [equalizer_mode.value for equalizer_mode in EqualizerMode]
+        return [equalizer_mode for equalizer_mode in EqualizerMode]
 
     @property
     def speaker_type(self) -> SpeakerType:

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -219,11 +219,11 @@ class LoopMode(StrEnum):
 class EqualizerMode(StrEnum):
     """Defines the equalizer mode."""
 
-    NONE = "0"
-    CLASSIC = "1"
-    POP = "2"
-    JAZZ = "3"
-    VOCAL = "4"
+    NONE = "None"
+    CLASSIC = "Classic"
+    POP = "Pop"
+    JAZZ = "Jazz"
+    VOCAL = "Vocal"
 
 
 class PlayingStatus(StrEnum):

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -236,6 +236,22 @@ async def test_player_set_equalizer_mode():
     bridge.request.assert_called_once_with(LinkPlayCommand.EQUALIZER_MODE.format(3))
 
 
+async def test_player_get_available_equalizer_modes():
+    """Tests if the player get available equalizer modes is correctly called."""
+    bridge = AsyncMock()
+    player = LinkPlayPlayer(bridge)
+
+    equalizer_modes = player.available_equalizer_modes
+
+    assert equalizer_modes == [
+        EqualizerMode.NONE,
+        EqualizerMode.CLASSIC,
+        EqualizerMode.POP,
+        EqualizerMode.JAZZ,
+        EqualizerMode.VOCAL,
+    ]
+
+
 async def test_player_set_loop_mode():
     """Tests if the player set loop mode is correctly called."""
     bridge = AsyncMock()

--- a/tests/linkplay/test_bridge.py
+++ b/tests/linkplay/test_bridge.py
@@ -232,7 +232,8 @@ async def test_player_set_equalizer_mode():
 
     await player.set_equalizer_mode(mode)
 
-    bridge.request.assert_called_once_with(LinkPlayCommand.EQUALIZER_MODE.format(mode))
+    # Equalizer.Jazz is to be mapped to 3
+    bridge.request.assert_called_once_with(LinkPlayCommand.EQUALIZER_MODE.format(3))
 
 
 async def test_player_set_loop_mode():


### PR DESCRIPTION
That way, we can support cases where not all equalizer modes are supported or when a device provides a different list of equalizer modes as provided in #75