### PR TITLE
Adding options to extract MetaInfo and set Audio Output on the HW (WiiM)

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")  
+        return str(self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,""))  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,9 +302,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str:
+    def album_art(self) -> dict[str,str]:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")  
+        return self.metainfo.get("metaData",{})  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,7 +302,7 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self):
+    def album_art(self) -> str:
         """Returns the url to the album art."""
         return self.metainfo.get("metaData").get(MetaInfoMetaData.ALBUM_ART,"")  
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -275,7 +275,7 @@ class LinkPlayPlayer:
     async def get_audio_output_hw_mode(self, mode: AudioOutputHwMode) -> None:
         """Get the audio hardware output."""
         await self.bridge.json_request(
-            LinkPlayCommand.AUDIO_OUTPUT_HW_MODE)
+            LinkPlayCommand.AUDIO_OUTPUT_HW_MODE
         )         
 
     @property

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -125,7 +125,7 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[str,str]
+    metainfo: dict[MetaInfoMetaData,str]
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
@@ -145,7 +145,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[str, str] = await self.bridge.json_request(
+            metainfo: dict[MetaInfoMetaData, str] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -294,8 +294,8 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> dict:
         """Returns the channel the player is playing on."""
-        _LOGGER.debug("Metainfo: %s", self.metainfo)
-        _LOGGER.debug("Metainfo metadata: %s", self.metainfo.get("metaData",{}))
+        LOGGER.debug("Metainfo: %s", self.metainfo)
+        LOGGER.debug("Metainfo metadata: %s", self.metainfo.get("metaData",{}))
         return self.metainfo['metaData'].get(MetaInfoMetaData.ALBUM_ART, "")             
 
     @property

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -301,9 +301,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str:
+    def album_art(self) -> dict[MetaInfoMetaData,str]:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"") 
+        return self.metainfo.get("metaData",{}) 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -270,8 +270,9 @@ class LinkPlayPlayer:
 
     async def set_audio_output_hw_mode(self, mode: AudioOutputHwMode) -> None:
         """Set the audio hardware output."""
+        LOGGER("mode: %s", mode)
         await self.bridge.request(
-            LinkPlayCommand.AUDIO_OUTPUT_HW_MODE_SET.format(AUDIO_OUTPUT_HW_MODE_MAP[mode])
+            LinkPlayCommand.AUDIO_OUTPUT_HW_MODE_SET.format(mode)
         )      
 
     async def get_audio_output_hw_mode(self, mode: AudioOutputHwMode) -> None:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -125,7 +125,7 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[MetaInfoMetaData,str]
+    metainfo: dict[str,str]
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
@@ -145,7 +145,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[MetaInfoMetaData, str] = await self.bridge.json_request(
+            metainfo: dict[str, str] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:
@@ -302,9 +302,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str:
+    def album_art(self) -> str | None:
         """Returns the url to the album art."""
-        return self.metainfo["metaData"].get(MetaInfoMetaData.ALBUM_ART,"")  
+        return self.metainfo["metaData"].get(MetaInfoMetaData.ALBUM_ART,None)  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -133,7 +133,7 @@ class LinkPlayPlayer:
         self.bridge = bridge
         self.properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
         self.custom_properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
-        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), "")
+        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), dict[MetaInfoMetaData,str])
 
     def to_dict(self):
         """Return the state of the LinkPlayPlayer."""

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -301,9 +301,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> dict[str,str]:
+    def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo.get('metaData',{}) 
+        return metadata.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"") 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,9 +302,10 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> dict[str,str]:
+    def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{})  
+        metadata = self.metainfo.get("metaData",{})
+        return metadata.get(MetaInfoMetaData.ALBUM_ART,"") 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -293,10 +293,8 @@ class LinkPlayPlayer:
         
     @property
     def album_art(self) -> dict:
-        """Returns the channel the player is playing on."""
-        LOGGER.debug("Metainfo: %s", self.metainfo)
-        LOGGER.debug("Metainfo metadata: %s", self.metainfo.get("metaData",{}))
-        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART, "")             
+        """Returns the url to the album art."""
+        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")             
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -125,13 +125,12 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[MetaInfoMetaData,str]
+    metainfo: dict[str,str]
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
         self.properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
         self.custom_properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
-        self.metainfo = dict.fromkeys(MetaInfoMetaData.__members__.values(), "")
 
     def to_dict(self):
         """Return the state of the LinkPlayPlayer."""
@@ -145,7 +144,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[MetaInfoMetaData, str] = await self.bridge.json_request(
+            metainfo: dict[str, str] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,9 +304,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> dict[str,str] = {}:
+    def album_art(self) -> Any:
         """Returns the url to the album art."""
-        return self.metainfo.get(MetaInfo.METADATA,{})
+        return self.metainfo.get(MetaInfo.METADATA,{}).get(MetaInfoMetaData.ALBUM_ART,"") 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -303,8 +303,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> str:
         """Returns the url to the album art."""
-        metadata = self.metainfo.get("metaData",{})
-        return metadata.get(MetaInfoMetaData.ALBUM_ART,"") 
+        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"") 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -127,13 +127,13 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[MetaInfo,dict[MetaInfoMetaData,str]] = {}
+    metainfo: dict[MetaInfo,{}] = {}
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
         self.properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
         self.custom_properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
-        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), dict[MetaInfoMetaData,str])
+        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), {}])
 
     def to_dict(self):
         """Return the state of the LinkPlayPlayer."""
@@ -147,7 +147,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[MetaInfo,dict[MetaInfoMetaData,str]] = await self.bridge.json_request(
+            metainfo: dict[MetaInfo,{}] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -296,7 +296,7 @@ class LinkPlayPlayer:
         """Returns the channel the player is playing on."""
         LOGGER.debug("Metainfo: %s", self.metainfo)
         LOGGER.debug("Metainfo metadata: %s", self.metainfo.get("metaData",{}))
-        return self.metainfo['metaData'].get(MetaInfoMetaData.ALBUM_ART, "")             
+        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART, "")             
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -303,7 +303,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> dict[MetaInfoMetaData,str]:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{}) 
+        return self.metainfo.get('metaData',{}) 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData").get(MetaInfoMetaData.ALBUM_ART,"")  
+        return self.metainfo["metaData"].get(MetaInfoMetaData.ALBUM_ART,"")  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> Any:
+    def album_art(self) -> str:
         """Returns the url to the album art."""
         return self.metainfo.get(MetaInfo.METADATA,{}).get(MetaInfoMetaData.ALBUM_ART,"") 
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import json
 from typing import Any
 
 from linkplay.consts import (
@@ -303,9 +304,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str:
+    def album_art(self) -> dict[str,str]:
         """Returns the url to the album art."""
-        return self.metainfo.get(MetaInfo.METADATA,{}).get(MetaInfoMetaData.ALBUM_ART,"") 
+        return json.loads(self.metainfo.get(MetaInfo.METADATA,{}))
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,9 +302,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str | None:
+    def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo["metaData"].get(MetaInfoMetaData.ALBUM_ART,None)  
+        return self.metainfo["metaData"].get(MetaInfoMetaData.ALBUM_ART,"")  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,7 +302,7 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str | None:
+    def album_art(self) -> None:
         """Returns the url to the album art."""
         return str(self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,""))  
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> dict[str,str]:
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{})  
+        return json.loads(self.metainfo.get("metaData",{}))
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -301,7 +301,7 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> dict[MetaInfoMetaData,str]:
+    def album_art(self) -> dict[str,str]:
         """Returns the url to the album art."""
         return self.metainfo.get('metaData',{}) 
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -127,7 +127,7 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[MetaInfo,{}] = {}
+    metainfo: dict[MetaInfo,dict]
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
@@ -147,7 +147,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[MetaInfo,{}] = await self.bridge.json_request(
+            metainfo: dict[MetaInfo,dict] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,9 +304,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> dict[str,str]:
+    def album_art(self) -> dict[str,str] = {}:
         """Returns the url to the album art."""
-        return json.loads(self.metainfo.get(MetaInfo.METADATA,{}))
+        return self.metainfo.get(MetaInfo.METADATA,{})
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo["metaData"].get(MetaInfoMetaData.ALBUM_ART,"")  
+        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -19,6 +19,7 @@ from linkplay.consts import (
     PlayingMode,
     PlayingStatus,
     SpeakerType,
+    MetaInfo,
     MetaInfoMetaData,
     AudioOutputHwMode,
     AUDIO_OUTPUT_HW_MODE_MAP                  
@@ -125,12 +126,13 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[str,str]
+    metainfo: dict[MetaInfo,str]
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
         self.properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
         self.custom_properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
+        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), "")
 
     def to_dict(self):
         """Return the state of the LinkPlayPlayer."""
@@ -144,7 +146,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[str, str] = await self.bridge.json_request(
+            metainfo: dict[MetaInfo, str] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:
@@ -303,7 +305,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> str:
         """Returns the url to the album art."""
-        return self.metainfo.get('metaData',{}).get(MetaInfoMetaData.ALBUM_ART,"") 
+        return self.metainfo.get(MetaInfo.METADATA,{}).get(MetaInfoMetaData.ALBUM_ART,"") 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -127,7 +127,7 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[MetaInfo,str]
+    metainfo: dict[MetaInfo,dict[MetaInfoMetaData,str]] = {}
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
@@ -147,7 +147,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[MetaInfo, str] = await self.bridge.json_request(
+            metainfo: dict[MetaInfo,dict[MetaInfoMetaData,str]] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,7 +302,7 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> str:
+    def album_art(self) -> str | None:
         """Returns the url to the album art."""
         return str(self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,""))  
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -133,7 +133,7 @@ class LinkPlayPlayer:
         self.bridge = bridge
         self.properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
         self.custom_properties = dict.fromkeys(PlayerAttribute.__members__.values(), "")
-        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), {}])
+        self.metainfo = dict.fromkeys(MetaInfo.__members__.values(), {})
 
     def to_dict(self):
         """Return the state of the LinkPlayPlayer."""

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -146,7 +146,7 @@ class LinkPlayPlayer:
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
             metainfo: dict[MetaInfoMetaData, str] = await self.bridge.json_request(
-                LinkPlayCommand.META_INFO)
+                LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:
             self.metainfo = {}
@@ -302,7 +302,7 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> dict:
+    def album_art(self) -> str:
         """Returns the url to the album art."""
         return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")  
 

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self):
         """Returns the url to the album art."""
-        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")  
+        return self.metainfo.get("metaData").get(MetaInfoMetaData.ALBUM_ART,"")  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -270,7 +270,7 @@ class LinkPlayPlayer:
 
     async def set_audio_output_hw_mode(self, mode: AudioOutputHwMode) -> None:
         """Set the audio hardware output."""
-        LOGGER("mode: %s", mode)
+        LOGGER.debug("mode: %s", mode)
         await self.bridge.request(
             LinkPlayCommand.AUDIO_OUTPUT_HW_MODE_SET.format(mode)
         )      

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -302,9 +302,9 @@ class LinkPlayPlayer:
         return self.properties.get(PlayerAttribute.ALBUM, "")
         
     @property
-    def album_art(self) -> None:
+    def album_art(self):
         """Returns the url to the album art."""
-        return str(self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,""))  
+        return self.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"")  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -304,7 +304,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> dict[str,str]:
         """Returns the url to the album art."""
-        return json.loads(self.metainfo.get("metaData",{}))
+        return self.metainfo.get("metaData",{})  
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -127,7 +127,7 @@ class LinkPlayPlayer:
     bridge: LinkPlayBridge
     properties: dict[PlayerAttribute, str]
     custom_properties: dict[PlayerAttribute, str]
-    metainfo: dict[MetaInfo,dict]
+    metainfo: dict[MetaInfo,dict[MetaInfoMetaData,str]]
 
     def __init__(self, bridge: LinkPlayBridge):
         self.bridge = bridge
@@ -147,7 +147,7 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            metainfo: dict[MetaInfo,dict] = await self.bridge.json_request(
+            metainfo: dict[MetaInfo,dict[MetaInfoMetaData,str]] = await self.bridge.json_request(
                 LinkPlayCommand.META_INFO) # type: ignore[assignment]
             self.metainfo = metainfo
         else:

--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -303,7 +303,7 @@ class LinkPlayPlayer:
     @property
     def album_art(self) -> str:
         """Returns the url to the album art."""
-        return metadata.metainfo.get("metaData",{}).get(MetaInfoMetaData.ALBUM_ART,"") 
+        return self.metainfo.get('metaData',{}).get(MetaInfoMetaData.ALBUM_ART,"") 
 
     @property
     def volume(self) -> int:

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -476,8 +476,17 @@ class MultiroomAttribute(StrEnum):
         
         
 class MetaInfoMetaData(StrEnum):
+    """Defines the metadata within the metainfo."""
 
+    ALBUM_TITLE = "album"
+    TRACK_TITLE = "title"
+    TRACK_SUBTITLE = "subtitle"
     ALBUM_ART = "albumArtURI"
+    SAMPLE_RATE = "sampleRate"
+    BIT_DEPTH = "bitDepth"
+    BIT_RATE = "bitRate"
+    TRACK_ID = "trackId"
+    
 
 class AudioOutputHwMode(StrEnum):
     """Defines a output mode for the hardware."""

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -474,6 +474,16 @@ class MultiroomAttribute(StrEnum):
     def __repr__(self):
         return self.value
         
+
+class MetaInfo(StrEnum):
+
+    METADATA = "metaData"
+    
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return self.value     
         
 class MetaInfoMetaData(StrEnum):
     """Defines the metadata within the metainfo."""

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -477,7 +477,7 @@ class MultiroomAttribute(StrEnum):
         
 class MetaInfoMetaData(StrEnum):
 
-    ALBUM_ART: "albumArtURI"
+    ALBUM_ART = "albumArtURI"
 
 class AudioOutputHwMode(StrEnum):
     """Defines a output mode for the hardware."""

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -475,7 +475,7 @@ class MultiroomAttribute(StrEnum):
         return self.value
         
         
-class MetaInfo(StrEnum):
+class MetaInfoMetaData(StrEnum):
 
     ALBUM_ART: "albumArtURI"
 

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -487,6 +487,12 @@ class MetaInfoMetaData(StrEnum):
     BIT_RATE = "bitRate"
     TRACK_ID = "trackId"
     
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return self.value    
+    
 
 class AudioOutputHwMode(StrEnum):
     """Defines a output mode for the hardware."""

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -100,6 +100,9 @@ class LinkPlayCommand(StrEnum):
     PLAY_PRESET = "MCUKeyShortClick:{}"
     TIMESYNC = "timeSync:{}"
     WIIM_EQ_LOAD = "EQLoad:{}"
+    META_INFO = "getMetaInfo"
+    AUDIO_OUTPUT_HW_MODE_SET = "setAudioOutputHardwareMode:{}"
+    AUDIO_OUTPUT_HW_MODE = "getNewAudioOutputHardwareMode"
 
 
 class LinkPlayTcpUartCommand(StrEnum):
@@ -470,3 +473,23 @@ class MultiroomAttribute(StrEnum):
 
     def __repr__(self):
         return self.value
+        
+        
+class MetaInfo(StrEnum):
+
+    ALBUM_ART: "albumArtURI"
+
+class AudioOutputHwMode(StrEnum):
+    """Defines a output mode for the hardware."""
+    OPTICAL = "1"
+    LINE_OUT = "2"
+    COAXIAL = "3"
+    HEADPHONES = "4"
+
+# Map between a play mode and how to activate the play mode
+AUDIO_OUTPUT_HW_MODE_MAP: dict[AudioOutputHwMode, str] = {  # case sensitive!
+    AudioOutputHwMode.OPTICAL: "optical",
+    AudioOutputHwMode.LINE_OUT: "line-out",
+    AudioOutputHwMode.COAXIAL: "co-axial",
+    AudioOutputHwMode.HEADPHONES: "headphones",
+}                                                       


### PR DESCRIPTION
Option getMetaInfo: 

- provides metadata with a.o. the url to the albumart. For now only that property is implemented as it overlaps with getPlayerStatus(Ex)

Options setNewAudioOutputHardwareMode and getNewAudioOutputHardwareMode :
- allow to set the hardware output, at least for WiiM (pro) 

Basis of functionality in this doc https://www.wiimhome.com/pdf/HTTP%20API%20for%20WiiM%20Products.pdf