### PR TITLE
Fix I/O in the event loop

### DIFF
--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -185,7 +185,7 @@ async def async_create_ssl_context(
     with contextlib.suppress(AttributeError):
         # This only works for OpenSSL >= 1.0.0
         sslcontext.options |= ssl.OP_NO_COMPRESSION
-    sslcontext.set_default_verify_paths()
+    await loop.run_in_executor(executor, sslcontext.set_default_verify_paths)
     return sslcontext
 
 


### PR DESCRIPTION
`context.set_default_verify_paths` is doing I/O. This PR fixes it.

I would recommend to rewrite all these methods to just be sync, and have 1 call into the executor at the top level function. It's quite inefficient to jump into executor to write to files, flush files, load files. Just 1 executor call could do the job.