### PR TITLE
Avoid errors that crash the code if result is not json

### DIFF
--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -78,6 +78,10 @@ async def session_call_api_json(
     """
     try:
         result = await session_call_api(endpoint, session, command)
+        try:
+            json.loads(result)
+        except ValueError as e:
+            return {}
         return json.loads(result)  # type: ignore
     except json.JSONDecodeError as jsonexc:
         url = API_ENDPOINT.format(endpoint, command)


### PR DESCRIPTION
httpapi calls can return json data, in certain cases, at least with getMetaInfo, it can return non json if the WiiM is inactive (beyond asleep) and it returns 'Failed'
By verifiying proper json and returning a {}, the subsequent processes should be able to continue

Addresses: https://github.com/Velleman/python-linkplay/issues/91