### PR TITLE
Handle "failed" returned as plain text to the WiiM metainfo command

### DIFF
--- a/src/linkplay/bridge.py
+++ b/src/linkplay/bridge.py
@@ -153,9 +153,15 @@ class LinkPlayPlayer:
 
         self.properties = fixup_player_properties(properties)
         if self.bridge.device.manufacturer == MANUFACTURER_WIIM:
-            self.metainfo: dict[
-                MetaInfo, dict[MetaInfoMetaData, str]
-            ] = await self.bridge.json_request(LinkPlayCommand.META_INFO)  # type: ignore[assignment]
+            try:
+                self.metainfo: dict[
+                    MetaInfo, dict[MetaInfoMetaData, str]
+                ] = await self.bridge.json_request(LinkPlayCommand.META_INFO)  # type: ignore[assignment]
+            except LinkPlayInvalidDataException as exc:
+                if getattr(exc, "data", None) == "Failed":
+                    self.metainfo = {}
+                else:
+                    raise
         else:
             self.metainfo = {}
 

--- a/src/linkplay/consts.py
+++ b/src/linkplay/consts.py
@@ -473,18 +473,18 @@ class MultiroomAttribute(StrEnum):
 
     def __repr__(self):
         return self.value
-        
+
 
 class MetaInfo(StrEnum):
-
     METADATA = "metaData"
-    
+
     def __str__(self):
         return self.value
 
     def __repr__(self):
-        return self.value     
-        
+        return self.value
+
+
 class MetaInfoMetaData(StrEnum):
     """Defines the metadata within the metainfo."""
 
@@ -496,20 +496,22 @@ class MetaInfoMetaData(StrEnum):
     BIT_DEPTH = "bitDepth"
     BIT_RATE = "bitRate"
     TRACK_ID = "trackId"
-    
+
     def __str__(self):
         return self.value
 
     def __repr__(self):
-        return self.value    
-    
+        return self.value
+
 
 class AudioOutputHwMode(StrEnum):
     """Defines a output mode for the hardware."""
+
     OPTICAL = "1"
     LINE_OUT = "2"
     COAXIAL = "3"
     HEADPHONES = "4"
+
 
 # Map between a play mode and how to activate the play mode
 AUDIO_OUTPUT_HW_MODE_MAP: dict[AudioOutputHwMode, str] = {  # case sensitive!
@@ -517,4 +519,4 @@ AUDIO_OUTPUT_HW_MODE_MAP: dict[AudioOutputHwMode, str] = {  # case sensitive!
     AudioOutputHwMode.LINE_OUT: "line-out",
     AudioOutputHwMode.COAXIAL: "co-axial",
     AudioOutputHwMode.HEADPHONES: "headphones",
-}                                                       
+}

--- a/src/linkplay/exceptions.py
+++ b/src/linkplay/exceptions.py
@@ -7,6 +7,6 @@ class LinkPlayRequestException(LinkPlayException):
 
 
 class LinkPlayInvalidDataException(LinkPlayException):
-    def __init__(self, message: str = "Invalid data received", data: str = None):
+    def __init__(self, message: str = "Invalid data received", data: str | None = None):
         super().__init__(message)
         self.data = data

--- a/src/linkplay/exceptions.py
+++ b/src/linkplay/exceptions.py
@@ -7,4 +7,6 @@ class LinkPlayRequestException(LinkPlayException):
 
 
 class LinkPlayInvalidDataException(LinkPlayException):
-    pass
+    def __init__(self, message: str = "Invalid data received", data: str = None):
+        super().__init__(message)
+        self.data = data

--- a/src/linkplay/utils.py
+++ b/src/linkplay/utils.py
@@ -82,7 +82,7 @@ async def session_call_api_json(
     except json.JSONDecodeError as jsonexc:
         url = API_ENDPOINT.format(endpoint, command)
         raise LinkPlayInvalidDataException(
-            f"Unexpected JSON ({result}) received from '{url}'"
+            message=f"Unexpected JSON ({result}) received from '{url}'", data=result
         ) from jsonexc
 
 


### PR DESCRIPTION
Closes #91 
Closes #92